### PR TITLE
Add state for extra packages to media handler machines. Only windows …

### DIFF
--- a/media/init.sls
+++ b/media/init.sls
@@ -1,0 +1,9 @@
+lightworks:
+  chocolatey.installed:
+    - name: lightworks
+audacity:
+  chocolatey.installed:
+    - audacity
+gimp:
+  chocolatey.installed:
+    - gimp


### PR DESCRIPTION
…because Lightworks is jank on Debian.